### PR TITLE
Handle provided BeforeInvocationEvent#errorCode in LastSecurityFilter Haulmont/jmix-security#87

### DIFF
--- a/security-oauth2/src/main/java/io/jmix/securityoauth2/event/BeforeInvocationEvent.java
+++ b/security-oauth2/src/main/java/io/jmix/securityoauth2/event/BeforeInvocationEvent.java
@@ -32,6 +32,7 @@ public class BeforeInvocationEvent extends ApplicationEvent {
     private final ServletRequest request;
     private final ServletResponse response;
     private boolean invocationPrevented = false;
+    private int errorCode;
 
     public BeforeInvocationEvent(Authentication authentication,
                                  ServletRequest request,
@@ -64,5 +65,13 @@ public class BeforeInvocationEvent extends ApplicationEvent {
 
     public void preventInvocation() {
         this.invocationPrevented = true;
+    }
+
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(int errorCode) {
+        this.errorCode = errorCode;
     }
 }

--- a/security-oauth2/src/main/java/io/jmix/securityoauth2/filter/LastSecurityFilter.java
+++ b/security-oauth2/src/main/java/io/jmix/securityoauth2/filter/LastSecurityFilter.java
@@ -86,6 +86,11 @@ public class LastSecurityFilter extends OncePerRequestFilter {
                         filterChain.doFilter(request, response);
                     } else {
                         log.debug("Request invocation prevented by BeforeInvocationEvent handler");
+                        int errorCode = beforeInvocationEvent.getErrorCode();
+                        if (errorCode > 0) {
+                            log.warn("Send an error response with errorCode {}", errorCode);
+                            response.sendError(errorCode);
+                        }
                     }
                 } finally {
                     applicationEventPublisher.publishEvent(new AfterInvocationEvent(authentication, request, response, invocationPrevented));


### PR DESCRIPTION
… Haulmont/jmix-security#87

In case when BeforeInvocationEvent prevent further request execution and contains errorCode we should not ignore provided errorCode and use it as response status.